### PR TITLE
Fix failed audits to handle none type scores

### DIFF
--- a/lighthouse/report.py
+++ b/lighthouse/report.py
@@ -97,7 +97,7 @@ class LighthouseReport(object):
                     'display': v.get('displayValue'),
                 })
                 for k, v in all_audits.items()
-                if v.get('score', 0) < 1 and
+                if (v.get('score', 0) or 0) < 1 and
                 v.get('scoreDisplayMode') not in sdm_to_reject
             ]
 


### PR DESCRIPTION
I noticed that when I was running my tests with this tool, I was getting an error when trying to access audits. This was caused by a few NoneType scores in the audit dict.

As the `.get()` was defaulting to zero/fail for non-present entries, I've just defaulted NoneType entries to 0 as well. 

No fix needed for passed audits as that uses an equality operator instead.